### PR TITLE
add support for Bower registration

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "bower_components",
+  "json": "bower.json"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 config.codekit
 .codekit-cache
 .sass-cache
+
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "twemoji-awesome",
+  "version": "0.1.0",
+  "homepage": "https://github.com/ellekasai/twemoji-awesome",
+  "description": "Like Font Awesome, but for Twitter Emoji",
+  "keywords": [
+    "emoji",
+    "twemoji",
+    "font",
+    "iconfont",
+    "icon",
+    "awesome"
+  ],
+  "authors": [
+    "ellekasai <elle.kasai@gmail.com> (http://ellekasai.com/)"
+  ],
+  "ignore": [
+    "bower_components",
+    ".bowerrc",
+    ".git",
+    ".gitignore"
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
With these changes, twemoji-awesome may be registered to Bower, and be made available to anybody in a breeze, with a simple `bower install twemoji-awesome`.

Then, to register the package:
- a 1st git tag is needed (say 0.1.0 as bower.json)
- `bower register twemoji-awesome git://github.com/ellekasai/twemoji-awesome.git`
